### PR TITLE
feat: support async loading of snowplow script

### DIFF
--- a/src/async-snowplow.test.ts
+++ b/src/async-snowplow.test.ts
@@ -1,0 +1,186 @@
+import { ImmediateAsyncSnowplow, TimerAsyncSnowplow } from './async-snowplow';
+
+jest.useFakeTimers();
+
+describe('ImmediateAsyncSnowplow', () => {
+  describe('call', () => {
+    it('success', () => {
+      const snowplow = jest.fn();
+      const asyncSnowplow = new ImmediateAsyncSnowplow(snowplow, (e) => {
+        throw e;
+      });
+      const event = { fake: 'prop' };
+      asyncSnowplow.call('trackUnstructEvent', event);
+      expect(snowplow.mock.calls.length).toBe(1);
+      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[0][1]).toEqual(event);
+    });
+
+    it('success', () => {
+      const snowplow = jest.fn(() => {
+        throw 'Failed';
+      });
+      const asyncSnowplow = new ImmediateAsyncSnowplow(snowplow, (e) => {
+        throw e;
+      });
+      const event = { fake: 'prop' };
+      expect(() => asyncSnowplow.call('trackUnstructEvent', event)).toThrow(/^Failed$/);
+    });
+  });
+
+  it('tryFlush', () => {
+    const snowplow = jest.fn();
+    const asyncSnowplow = new ImmediateAsyncSnowplow(snowplow, (e) => {
+      throw e;
+    });
+    asyncSnowplow.tryFlush();
+    // Nothing should happen.
+  });
+});
+
+// Call ends up testing tryFlush and createTimerIfNeeded.
+describe('TimerAsyncSnowplow - call', () => {
+  describe('success', () => {
+    it('immediate', () => {
+      const snowplow = jest.fn();
+      const asyncSnowplow = new TimerAsyncSnowplow(
+        () => snowplow,
+        (e) => {
+          throw e;
+        }
+      );
+      const event = { fake: 'prop' };
+      asyncSnowplow.call('trackUnstructEvent', event);
+      expect(snowplow.mock.calls.length).toBe(1);
+      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[0][1]).toEqual(event);
+    });
+
+    it('timer', () => {
+      let snowplow: any = undefined;
+      const asyncSnowplow = new TimerAsyncSnowplow(
+        () => snowplow,
+        (e) => {
+          throw e;
+        }
+      );
+      const event = { fake: 'prop' };
+      asyncSnowplow.call('trackUnstructEvent', event);
+      snowplow = jest.fn();
+      jest.runAllTimers();
+      expect(snowplow.mock.calls.length).toBe(1);
+      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[0][1]).toEqual(event);
+    });
+
+    it('timer 3x', () => {
+      let snowplow: any = undefined;
+      const asyncSnowplow = new TimerAsyncSnowplow(
+        () => snowplow,
+        (e) => {
+          throw e;
+        }
+      );
+      const event0 = { fake: 'prop0' };
+      asyncSnowplow.call('trackUnstructEvent', event0);
+      const event1 = { fake: 'prop1' };
+      asyncSnowplow.call('trackUnstructEvent', event1);
+      snowplow = jest.fn();
+      jest.runAllTimers();
+      expect(snowplow.mock.calls.length).toBe(2);
+      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[0][1]).toEqual(event0);
+      expect(snowplow.mock.calls[1][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[1][1]).toEqual(event1);
+      const event2 = { fake: 'prop2' };
+      asyncSnowplow.call('trackUnstructEvent', event2);
+      expect(snowplow.mock.calls.length).toBe(3);
+      expect(snowplow.mock.calls[2][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[2][1]).toEqual(event2);
+    });
+  });
+
+  describe('error', () => {
+    it('immediate', () => {
+      const snowplow = jest.fn(() => {
+        throw 'Failed';
+      });
+      const asyncSnowplow = new TimerAsyncSnowplow(
+        () => snowplow,
+        (e) => {
+          throw e;
+        }
+      );
+      const event = { fake: 'prop' };
+      expect(() => asyncSnowplow.call('trackUnstructEvent', event)).toThrow(/^Failed$/);
+    });
+
+    it('timer 3x', () => {
+      let snowplow: any = undefined;
+      const asyncSnowplow = new TimerAsyncSnowplow(
+        () => snowplow,
+        (e) => {
+          throw e;
+        }
+      );
+      const event0 = { fake: 'prop0' };
+      asyncSnowplow.call('trackUnstructEvent', event0);
+      const event1 = { fake: 'prop1' };
+      asyncSnowplow.call('trackUnstructEvent', event1);
+      let i = 0;
+      snowplow = jest.fn(() => {
+        // Fail every other call.
+        if (i % 2 === 1) {
+          throw 'Failed';
+        }
+        i++;
+      });
+      expect(() => jest.runAllTimers()).toThrow(/^Failed$/);
+      expect(snowplow.mock.calls.length).toBe(2);
+      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[0][1]).toEqual(event0);
+      expect(snowplow.mock.calls[1][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[1][1]).toEqual(event1);
+      const event2 = { fake: 'prop2' };
+      expect(() => asyncSnowplow.call('trackUnstructEvent', event2)).toThrow(/^Failed$/);
+    });
+  });
+
+  describe('test max attempt', () => {
+    it('right before the max', () => {
+      let snowplow: any = undefined;
+      const asyncSnowplow = new TimerAsyncSnowplow(
+        () => snowplow,
+        (e) => {
+          throw e;
+        }
+      );
+      const event = { fake: 'prop' };
+      asyncSnowplow.call('trackUnstructEvent', event);
+      for (let i = 0; i < 14; i++) {
+        jest.runOnlyPendingTimers();
+      }
+      snowplow = jest.fn();
+      jest.runAllTimers();
+      expect(snowplow.mock.calls.length).toBe(1);
+      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
+      expect(snowplow.mock.calls[0][1]).toEqual(event);
+    });
+
+    it('exceed max', () => {
+      const snowplow: any = undefined;
+      const asyncSnowplow = new TimerAsyncSnowplow(
+        () => snowplow,
+        (e) => {
+          throw e;
+        }
+      );
+      const event = { fake: 'prop' };
+      asyncSnowplow.call('trackUnstructEvent', event);
+      for (let i = 0; i < 14; i++) {
+        jest.runOnlyPendingTimers();
+      }
+      expect(() => jest.runOnlyPendingTimers()).toThrow(/^Max Snow timers exceeded$/);
+    });
+  });
+});

--- a/src/async-snowplow.test.ts
+++ b/src/async-snowplow.test.ts
@@ -11,9 +11,7 @@ describe('ImmediateAsyncSnowplow', () => {
       });
       const event = { fake: 'prop' };
       asyncSnowplow.call('trackUnstructEvent', event);
-      expect(snowplow.mock.calls.length).toBe(1);
-      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[0][1]).toEqual(event);
+      expect(snowplow.mock.calls).toEqual([['trackUnstructEvent', event]]);
     });
 
     it('success', () => {
@@ -28,17 +26,18 @@ describe('ImmediateAsyncSnowplow', () => {
     });
   });
 
-  it('tryFlush', () => {
+  it('flushEarlyEvents', () => {
     const snowplow = jest.fn();
     const asyncSnowplow = new ImmediateAsyncSnowplow(snowplow, (e) => {
       throw e;
     });
-    asyncSnowplow.tryFlush();
+    asyncSnowplow.flushEarlyEvents();
     // Nothing should happen.
+    expect(snowplow).not.toHaveBeenCalled();
   });
 });
 
-// Call ends up testing tryFlush and createTimerIfNeeded.
+// Call ends up testing flushEarlyEvents and createTimerIfNeeded.
 describe('TimerAsyncSnowplow - call', () => {
   describe('success', () => {
     it('immediate', () => {
@@ -51,9 +50,7 @@ describe('TimerAsyncSnowplow - call', () => {
       );
       const event = { fake: 'prop' };
       asyncSnowplow.call('trackUnstructEvent', event);
-      expect(snowplow.mock.calls.length).toBe(1);
-      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[0][1]).toEqual(event);
+      expect(snowplow.mock.calls).toEqual([['trackUnstructEvent', event]]);
     });
 
     it('timer', () => {
@@ -68,9 +65,7 @@ describe('TimerAsyncSnowplow - call', () => {
       asyncSnowplow.call('trackUnstructEvent', event);
       snowplow = jest.fn();
       jest.runAllTimers();
-      expect(snowplow.mock.calls.length).toBe(1);
-      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[0][1]).toEqual(event);
+      expect(snowplow.mock.calls).toEqual([['trackUnstructEvent', event]]);
     });
 
     it('timer 3x', () => {
@@ -87,16 +82,17 @@ describe('TimerAsyncSnowplow - call', () => {
       asyncSnowplow.call('trackUnstructEvent', event1);
       snowplow = jest.fn();
       jest.runAllTimers();
-      expect(snowplow.mock.calls.length).toBe(2);
-      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[0][1]).toEqual(event0);
-      expect(snowplow.mock.calls[1][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[1][1]).toEqual(event1);
+      expect(snowplow.mock.calls).toEqual([
+        ['trackUnstructEvent', event0],
+        ['trackUnstructEvent', event1],
+      ]);
       const event2 = { fake: 'prop2' };
       asyncSnowplow.call('trackUnstructEvent', event2);
-      expect(snowplow.mock.calls.length).toBe(3);
-      expect(snowplow.mock.calls[2][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[2][1]).toEqual(event2);
+      expect(snowplow.mock.calls).toEqual([
+        ['trackUnstructEvent', event0],
+        ['trackUnstructEvent', event1],
+        ['trackUnstructEvent', event2],
+      ]);
     });
   });
 
@@ -136,11 +132,10 @@ describe('TimerAsyncSnowplow - call', () => {
         i++;
       });
       expect(() => jest.runAllTimers()).toThrow(/^Failed$/);
-      expect(snowplow.mock.calls.length).toBe(2);
-      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[0][1]).toEqual(event0);
-      expect(snowplow.mock.calls[1][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[1][1]).toEqual(event1);
+      expect(snowplow.mock.calls).toEqual([
+        ['trackUnstructEvent', event0],
+        ['trackUnstructEvent', event1],
+      ]);
       const event2 = { fake: 'prop2' };
       expect(() => asyncSnowplow.call('trackUnstructEvent', event2)).toThrow(/^Failed$/);
     });
@@ -162,9 +157,7 @@ describe('TimerAsyncSnowplow - call', () => {
       }
       snowplow = jest.fn();
       jest.runAllTimers();
-      expect(snowplow.mock.calls.length).toBe(1);
-      expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-      expect(snowplow.mock.calls[0][1]).toEqual(event);
+      expect(snowplow.mock.calls).toEqual([['trackUnstructEvent', event]]);
     });
 
     it('exceed max', () => {

--- a/src/async-snowplow.ts
+++ b/src/async-snowplow.ts
@@ -1,0 +1,119 @@
+export type SnowplowFn = (...args: any[]) => void;
+
+/**
+ * Wraps Snowplow method and allows for flushing a bunch of Snowplow calls.
+ */
+export interface AsyncSnowplow {
+  /**
+   * Same as calling Snowplow but will queue the events if Snowplow is not loaded.
+   */
+  call(...args: any[]): void;
+
+  /**
+   * Tries to flush the queue if Snowplow is setup.
+   */
+  tryFlush(): void;
+}
+
+/**
+ * A version of AsyncSnowplow that runs the calls immediately.  A valid
+ * SnowplowFn must be passed into the constructor.
+ */
+export class ImmediateAsyncSnowplow implements AsyncSnowplow {
+  snowplow: SnowplowFn;
+  handleLogError: (err: Error) => void;
+
+  public constructor(snowplow: SnowplowFn, handleLogError: (err: Error) => void) {
+    this.snowplow = snowplow;
+    this.handleLogError = handleLogError;
+  }
+
+  call(...args: any[]) {
+    try {
+      this.snowplow(...args);
+    } catch (e) {
+      this.handleLogError(e);
+    }
+  }
+
+  tryFlush() {
+    // Do nothing.
+  }
+}
+
+// @ts-expect-error window does not have snowplow on it.
+export const windowSnowplowProvider = () => typeof window !== 'undefined' && window?.snowplow;
+
+const SLEEP_DURATION_MS = 2000;
+const MAX_TIMER_ATTEMPTS = 15;
+
+/**
+ * An implementation of AsyncSnowplow that is backed by a timer.
+ */
+export class TimerAsyncSnowplow implements AsyncSnowplow {
+  snowplowProvider: () => SnowplowFn | undefined;
+  handleLogError: (err: Error) => void;
+  queue: any[][];
+  timer: ReturnType<typeof setTimeout> | undefined;
+  numTimerAttempts = 0;
+
+  public constructor(snowplowProvider: () => SnowplowFn | undefined, handleLogError: (err: Error) => void) {
+    this.snowplowProvider = snowplowProvider;
+    this.handleLogError = handleLogError;
+    this.queue = [];
+  }
+
+  call(...args: any[]) {
+    const snowplow = this.snowplowProvider();
+    if (snowplow) {
+      snowplow(...args);
+    } else {
+      // Delay call.
+      this.queue.push(args);
+      this.createTimerIfNeeded();
+    }
+  }
+
+  tryFlush() {
+    if (this.queue.length > 0) {
+      try {
+        const snowplow = this.snowplowProvider();
+        if (snowplow) {
+          const newQueue: any[][] = [];
+          let error: Error | undefined = undefined;
+          this.queue.forEach((args) => {
+            try {
+              snowplow(...args);
+            } catch (e) {
+              newQueue.push(args);
+              error = e;
+            }
+          });
+          this.queue = newQueue;
+          if (error !== undefined) {
+            throw error;
+          }
+        } else {
+          // Make sure another timer exists.
+          this.createTimerIfNeeded();
+        }
+      } catch (e) {
+        this.handleLogError(e);
+      }
+    }
+  }
+
+  createTimerIfNeeded() {
+    if (this.queue.length > 0 && !this.timer) {
+      if (this.numTimerAttempts >= MAX_TIMER_ATTEMPTS) {
+        this.handleLogError(new Error('Max Snow timers exceeded'));
+      } else {
+        this.numTimerAttempts++;
+        this.timer = setTimeout(() => {
+          this.timer = undefined;
+          this.tryFlush();
+        }, SLEEP_DURATION_MS);
+      }
+    }
+  }
+}

--- a/src/async-snowplow.ts
+++ b/src/async-snowplow.ts
@@ -12,7 +12,7 @@ export interface AsyncSnowplow {
   /**
    * Tries to flush the queue if Snowplow is setup.
    */
-  tryFlush(): void;
+  flushEarlyEvents(): void;
 }
 
 /**
@@ -36,7 +36,7 @@ export class ImmediateAsyncSnowplow implements AsyncSnowplow {
     }
   }
 
-  tryFlush() {
+  flushEarlyEvents() {
     // Do nothing.
   }
 }
@@ -74,7 +74,7 @@ export class TimerAsyncSnowplow implements AsyncSnowplow {
     }
   }
 
-  tryFlush() {
+  flushEarlyEvents() {
     if (this.queue.length > 0) {
       try {
         const snowplow = this.snowplowProvider();
@@ -111,7 +111,7 @@ export class TimerAsyncSnowplow implements AsyncSnowplow {
         this.numTimerAttempts++;
         this.timer = setTimeout(() => {
           this.timer = undefined;
-          this.tryFlush();
+          this.flushEarlyEvents();
         }, SLEEP_DURATION_MS);
       }
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,16 +96,19 @@ describe('logUser', () => {
     };
     logger.innerLogUser(cf, user);
 
-    expect(snowplow.mock.calls.length).toBe(1);
-    expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-    expect(snowplow.mock.calls[0][1]).toEqual({
-      schema: 'iglu:ai.promoted.test/user/jsonschema/1-0-0',
-      data: {
-        common: {
-          logUserId: 'log-user-id',
+    expect(snowplow.mock.calls).toEqual([
+      [
+        'trackUnstructEvent',
+        {
+          schema: 'iglu:ai.promoted.test/user/jsonschema/1-0-0',
+          data: {
+            common: {
+              logUserId: 'log-user-id',
+            },
+          },
         },
-      },
-    });
+      ],
+    ]);
     expect(localStorage.items).toEqual({
       'p-uh': '79fde9e6f22beefc8863cae0df052eb4dd56babf',
       'p-us': 'session-id1',
@@ -160,17 +163,20 @@ describe('logCohortMembership', () => {
     } as CohortMembership;
     logger.logCohortMembership(cohortMembership);
 
-    expect(snowplow.mock.calls.length).toBe(1);
-    expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-    expect(snowplow.mock.calls[0][1]).toEqual({
-      schema: 'iglu:ai.promoted.test/cohortmembership/jsonschema/1-0-0',
-      data: {
-        common: {
-          cohort_id: 'UNKNOWN_COHORT',
-          experimentGroup: 'EXPERIMENT',
+    expect(snowplow.mock.calls).toEqual([
+      [
+        'trackUnstructEvent',
+        {
+          schema: 'iglu:ai.promoted.test/cohortmembership/jsonschema/1-0-0',
+          data: {
+            common: {
+              cohort_id: 'UNKNOWN_COHORT',
+              experimentGroup: 'EXPERIMENT',
+            },
+          },
         },
-      },
-    });
+      ],
+    ]);
   });
 
   it('error', () => {
@@ -215,18 +221,21 @@ describe('logView', () => {
     } as View;
     logger.logView(view);
 
-    expect(snowplow.mock.calls.length).toBe(1);
-    expect(snowplow.mock.calls[0][0]).toEqual('trackPageView');
-    expect(snowplow.mock.calls[0][1]).toEqual(null);
-    expect(snowplow.mock.calls[0][2]).toEqual([
-      {
-        data: {
-          common: {
-            useCase: 'SEARCH',
+    expect(snowplow.mock.calls).toEqual([
+      [
+        'trackPageView',
+        null,
+        [
+          {
+            data: {
+              common: {
+                useCase: 'SEARCH',
+              },
+            },
+            schema: 'iglu:ai.promoted/pageview_cx/jsonschema/2-0-0',
           },
-        },
-        schema: 'iglu:ai.promoted/pageview_cx/jsonschema/2-0-0',
-      },
+        ],
+      ],
     ]);
   });
 
@@ -273,18 +282,21 @@ describe('logRequest', () => {
     } as Request;
     logger.logRequest(request);
 
-    expect(snowplow.mock.calls.length).toBe(1);
-    expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-    expect(snowplow.mock.calls[0][1]).toEqual({
-      schema: 'iglu:ai.promoted.test/request/jsonschema/1-0-0',
-      data: {
-        common: {
-          requestId: 'abc-xyz',
-          useCase: 'SEARCH',
+    expect(snowplow.mock.calls).toEqual([
+      [
+        'trackUnstructEvent',
+        {
+          schema: 'iglu:ai.promoted.test/request/jsonschema/1-0-0',
+          data: {
+            common: {
+              requestId: 'abc-xyz',
+              useCase: 'SEARCH',
+            },
+            experimentOneGroup: 1,
+          },
         },
-        experimentOneGroup: 1,
-      },
-    });
+      ],
+    ]);
   });
 
   it('error', () => {
@@ -334,20 +346,23 @@ describe('logInsertion', () => {
     } as Insertion;
     logger.logInsertion(insertion);
 
-    expect(snowplow.mock.calls.length).toBe(1);
-    expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-    expect(snowplow.mock.calls[0][1]).toEqual({
-      schema: 'iglu:ai.promoted.test/insertion/jsonschema/1-0-0',
-      data: {
-        common: {
-          contentId: '123',
-          insertionId: 'abc-xyz',
+    expect(snowplow.mock.calls).toEqual([
+      [
+        'trackUnstructEvent',
+        {
+          schema: 'iglu:ai.promoted.test/insertion/jsonschema/1-0-0',
+          data: {
+            common: {
+              contentId: '123',
+              insertionId: 'abc-xyz',
+            },
+            shirt: {
+              color: 'blue',
+            },
+          },
         },
-        shirt: {
-          color: 'blue',
-        },
-      },
-    });
+      ],
+    ]);
   });
 
   it('error', () => {
@@ -396,17 +411,20 @@ describe('logImpression', () => {
     } as Impression;
     logger.logImpression(impression);
 
-    expect(snowplow.mock.calls.length).toBe(1);
-    expect(snowplow.mock.calls[0][0]).toEqual('trackUnstructEvent');
-    expect(snowplow.mock.calls[0][1]).toEqual({
-      schema: 'iglu:ai.promoted.test/impression/jsonschema/1-0-0',
-      data: {
-        common: {
-          impressionId: 'abc-xyz',
+    expect(snowplow.mock.calls).toEqual([
+      [
+        'trackUnstructEvent',
+        {
+          schema: 'iglu:ai.promoted.test/impression/jsonschema/1-0-0',
+          data: {
+            common: {
+              impressionId: 'abc-xyz',
+            },
+            timeMillis: 123456789,
+          },
         },
-        timeMillis: 123456789,
-      },
-    });
+      ],
+    ]);
   });
 
   it('error', () => {
@@ -451,20 +469,23 @@ describe('logClick', () => {
     };
     logger.logClick(click);
 
-    expect(snowplow.mock.calls.length).toBe(1);
-    expect(snowplow.mock.calls[0][0]).toEqual('trackLinkClick');
-    expect(snowplow.mock.calls[0][1]).toEqual('target-url');
-    expect(snowplow.mock.calls[0][2]).toEqual('element-id');
-    expect(snowplow.mock.calls[0][3]).toEqual([]);
-    expect(snowplow.mock.calls[0][4]).toEqual('');
-    expect(snowplow.mock.calls[0][5]).toEqual('');
-    expect(snowplow.mock.calls[0][6]).toEqual([
-      {
-        schema: 'iglu:ai.promoted/impression_cx/jsonschema/1-0-0',
-        data: {
-          impressionId: 'abc-xyz',
-        },
-      },
+    expect(snowplow.mock.calls).toEqual([
+      [
+        'trackLinkClick',
+        'target-url',
+        'element-id',
+        [],
+        '',
+        '',
+        [
+          {
+            schema: 'iglu:ai.promoted/impression_cx/jsonschema/1-0-0',
+            data: {
+              impressionId: 'abc-xyz',
+            },
+          },
+        ],
+      ],
     ]);
   });
 
@@ -490,7 +511,7 @@ describe('logClick', () => {
   });
 });
 
-describe('tryFlush', () => {
+describe('flushEarlyEvents', () => {
   it('success', () => {
     const snowplow = jest.fn();
     const logger = createEventLogger({
@@ -501,7 +522,8 @@ describe('tryFlush', () => {
       snowplow,
       localStorage: mockLocalStorage(),
     });
-    // Does nothing.
-    logger.tryFlush();
+    logger.flushEarlyEvents();
+    // Nothing should happen.
+    expect(snowplow).not.toHaveBeenCalled();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -136,7 +136,7 @@ describe('logUser', () => {
         return [, , , , , , 'session-id1'];
       },
     };
-    expect(() => logger.innerLogUser(cf, user)).toThrow(/^Inner fail: Failed$/);
+    expect(() => logger.innerLogUser(cf, user)).toThrow(/^Inner fail: Inner fail: Failed$/);
   });
 });
 
@@ -487,5 +487,21 @@ describe('logClick', () => {
       elementId: 'element-id',
     };
     expect(() => logger.logClick(click)).toThrow(/^Inner fail: Failed$/);
+  });
+});
+
+describe('tryFlush', () => {
+  it('success', () => {
+    const snowplow = jest.fn();
+    const logger = createEventLogger({
+      platformName,
+      handleLogError: (err: Error) => {
+        throw err;
+      },
+      snowplow,
+      localStorage: mockLocalStorage(),
+    });
+    // Does nothing.
+    logger.tryFlush();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,7 @@ interface EventLogger {
   /**
    * Flush any Snowplow events that have been queued up in the EventLogger.
    */
-  tryFlush(): void;
+  flushEarlyEvents(): void;
 }
 
 export const createEventLogger = (args: EventLoggerArguments) => {
@@ -228,7 +228,7 @@ export class NoopEventLogger implements EventLogger {
     /* No op. */
   }
 
-  tryFlush() {
+  flushEarlyEvents() {
     /* No op. */
   }
 }
@@ -430,7 +430,7 @@ export class EventLoggerImpl implements EventLogger {
     this.snowplow.call('trackLinkClick', targetUrl, elementId, [], '', '', getImpressionContexts(impressionId));
   }
 
-  tryFlush() {
-    this.snowplow.tryFlush();
+  flushEarlyEvents() {
+    this.snowplow.flushEarlyEvents();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,7 +349,7 @@ export class EventLoggerImpl implements EventLogger {
     const self = this;
 
     // This version of the snowplow method allows us to get access to `cf`.
-    this.snowplow.call(function () {
+    this.snowplow.callSnowplow(function () {
       // We use cf to get sessionId.
       // @ts-expect-error Snowplow docs recommend this calling pattern.
       self.innerLogUser(this.cf, user);
@@ -374,7 +374,7 @@ export class EventLoggerImpl implements EventLogger {
         console.log(oldUserHash);
       }
       if (sessionId !== oldSessionId || newUserHash !== oldUserHash) {
-        this.snowplow.call('trackUnstructEvent', {
+        this.snowplow.callSnowplow('trackUnstructEvent', {
           schema,
           data: user,
         });
@@ -387,47 +387,47 @@ export class EventLoggerImpl implements EventLogger {
   }
 
   logCohortMembership(cohortMembership: CohortMembership) {
-    this.snowplow.call('trackUnstructEvent', {
+    this.snowplow.callSnowplow('trackUnstructEvent', {
       schema: this.getCohortMembershipIgluSchema(),
       data: cohortMembership,
     });
   }
 
   logView(view: View) {
-    this.snowplow.call('trackPageView', null, getViewContexts(view));
+    this.snowplow.callSnowplow('trackPageView', null, getViewContexts(view));
   }
 
   logRequest(request: Request) {
     // Q - should I add viewId here on the server?
-    this.snowplow.call('trackUnstructEvent', {
+    this.snowplow.callSnowplow('trackUnstructEvent', {
       schema: this.getRequestIgluSchema(),
       data: request,
     });
   }
 
   logInsertion(insertion: Insertion) {
-    this.snowplow.call('trackUnstructEvent', {
+    this.snowplow.callSnowplow('trackUnstructEvent', {
       schema: this.getInsertionIgluSchema(),
       data: insertion,
     });
   }
 
   logImpression(impression: Impression) {
-    this.snowplow.call('trackUnstructEvent', {
+    this.snowplow.callSnowplow('trackUnstructEvent', {
       schema: this.getImpressionIgluSchema(),
       data: impression,
     });
   }
 
   logAction(action: Action) {
-    this.snowplow.call('trackUnstructEvent', {
+    this.snowplow.callSnowplow('trackUnstructEvent', {
       schema: this.getActionIgluSchema(),
       data: action,
     });
   }
 
   logClick({ impressionId, targetUrl, elementId }: Click) {
-    this.snowplow.call('trackLinkClick', targetUrl, elementId, [], '', '', getImpressionContexts(impressionId));
+    this.snowplow.callSnowplow('trackLinkClick', targetUrl, elementId, [], '', '', getImpressionContexts(impressionId));
   }
 
   flushEarlyEvents() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 import hash from 'object-hash';
+import {
+  AsyncSnowplow,
+  ImmediateAsyncSnowplow,
+  SnowplowFn,
+  TimerAsyncSnowplow,
+  windowSnowplowProvider,
+} from './async-snowplow';
 
 /**
  * Constructor arguments for EventLogger.
@@ -171,6 +178,11 @@ interface EventLogger {
    * Logs `click`.
    */
   logClick(click: Click): void;
+
+  /**
+   * Flush any Snowplow events that have been queued up in the EventLogger.
+   */
+  tryFlush(): void;
 }
 
 export const createEventLogger = (args: EventLoggerArguments) => {
@@ -215,7 +227,18 @@ export class NoopEventLogger implements EventLogger {
   logClick() {
     /* No op. */
   }
+
+  tryFlush() {
+    /* No op. */
+  }
 }
+
+const createAsyncSnowplow = (overrideSnowplow: SnowplowFn | undefined, handleLogError: (err: Error) => void) => {
+  if (overrideSnowplow) {
+    return new ImmediateAsyncSnowplow(overrideSnowplow, handleLogError);
+  }
+  return new TimerAsyncSnowplow(windowSnowplowProvider, handleLogError);
+};
 
 /**
  * A utility class for logging events.
@@ -236,7 +259,7 @@ export class EventLoggerImpl implements EventLogger {
   private actionIgluSchema?: string;
 
   private handleLogError: (err: Error) => void;
-  private snowplow: (...args: any[]) => void;
+  private snowplow: AsyncSnowplow;
   private localStorage?: LocalStorage;
   private userSessionLocalStorageKey: string;
   private userHashLocalStorageKey: string;
@@ -247,15 +270,7 @@ export class EventLoggerImpl implements EventLogger {
   public constructor(args: EventLoggerArguments) {
     this.platformName = args.platformName;
     this.handleLogError = args.handleLogError;
-    // @ts-expect-error window does not have snowplow on it.
-    const sp = args.snowplow || (typeof window !== 'undefined' && window?.snowplow);
-    this.snowplow = (...args: any[]) => {
-      // Delay the error in case the client is using NextJS.
-      if (!this.snowplow) {
-        throw Error(`snowplow needs to be set on EventLogger constructor arguments or accessible on window`);
-      }
-      sp(...args);
-    };
+    this.snowplow = createAsyncSnowplow(args.snowplow, args.handleLogError);
     this.localStorage = args.localStorage;
     if (this.localStorage === undefined && typeof window !== 'undefined') {
       this.localStorage = window?.localStorage;
@@ -334,7 +349,7 @@ export class EventLoggerImpl implements EventLogger {
     const self = this;
 
     // This version of the snowplow method allows us to get access to `cf`.
-    this.snowplow(function () {
+    this.snowplow.call(function () {
       // We use cf to get sessionId.
       // @ts-expect-error Snowplow docs recommend this calling pattern.
       self.innerLogUser(this.cf, user);
@@ -359,7 +374,7 @@ export class EventLoggerImpl implements EventLogger {
         console.log(oldUserHash);
       }
       if (sessionId !== oldSessionId || newUserHash !== oldUserHash) {
-        this.snowplow('trackUnstructEvent', {
+        this.snowplow.call('trackUnstructEvent', {
           schema,
           data: user,
         });
@@ -372,74 +387,50 @@ export class EventLoggerImpl implements EventLogger {
   }
 
   logCohortMembership(cohortMembership: CohortMembership) {
-    try {
-      this.snowplow('trackUnstructEvent', {
-        schema: this.getCohortMembershipIgluSchema(),
-        data: cohortMembership,
-      });
-    } catch (error) {
-      this.handleLogError(error);
-    }
+    this.snowplow.call('trackUnstructEvent', {
+      schema: this.getCohortMembershipIgluSchema(),
+      data: cohortMembership,
+    });
   }
 
   logView(view: View) {
-    try {
-      this.snowplow('trackPageView', null, getViewContexts(view));
-    } catch (error) {
-      this.handleLogError(error);
-    }
+    this.snowplow.call('trackPageView', null, getViewContexts(view));
   }
 
   logRequest(request: Request) {
-    try {
-      // Q - should I add viewId here on the server?
-      this.snowplow('trackUnstructEvent', {
-        schema: this.getRequestIgluSchema(),
-        data: request,
-      });
-    } catch (error) {
-      this.handleLogError(error);
-    }
+    // Q - should I add viewId here on the server?
+    this.snowplow.call('trackUnstructEvent', {
+      schema: this.getRequestIgluSchema(),
+      data: request,
+    });
   }
 
   logInsertion(insertion: Insertion) {
-    try {
-      this.snowplow('trackUnstructEvent', {
-        schema: this.getInsertionIgluSchema(),
-        data: insertion,
-      });
-    } catch (error) {
-      this.handleLogError(error);
-    }
+    this.snowplow.call('trackUnstructEvent', {
+      schema: this.getInsertionIgluSchema(),
+      data: insertion,
+    });
   }
 
   logImpression(impression: Impression) {
-    try {
-      this.snowplow('trackUnstructEvent', {
-        schema: this.getImpressionIgluSchema(),
-        data: impression,
-      });
-    } catch (error) {
-      this.handleLogError(error);
-    }
+    this.snowplow.call('trackUnstructEvent', {
+      schema: this.getImpressionIgluSchema(),
+      data: impression,
+    });
   }
 
   logAction(action: Action) {
-    try {
-      this.snowplow('trackUnstructEvent', {
-        schema: this.getActionIgluSchema(),
-        data: action,
-      });
-    } catch (error) {
-      this.handleLogError(error);
-    }
+    this.snowplow.call('trackUnstructEvent', {
+      schema: this.getActionIgluSchema(),
+      data: action,
+    });
   }
 
   logClick({ impressionId, targetUrl, elementId }: Click) {
-    try {
-      this.snowplow('trackLinkClick', targetUrl, elementId, [], '', '', getImpressionContexts(impressionId));
-    } catch (error) {
-      this.handleLogError(error);
-    }
+    this.snowplow.call('trackLinkClick', targetUrl, elementId, [], '', '', getImpressionContexts(impressionId));
+  }
+
+  tryFlush() {
+    this.snowplow.tryFlush();
   }
 }


### PR DESCRIPTION
This library has two major changes:
1. We will queue the events until either the Snowplow script loads or or up to 30 seconds.
2. We expose the tryFlush method in case the loading script wants to call it directly.

There's some smaller refactoring to simplify the code.

TESTING=unit tests