### PR TITLE
fix: semantic release github action

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -31,7 +31,8 @@ jobs:
         run: npm run build
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        # Dan Hill reviewed this version.
+        uses: cycjimmy/semantic-release-action@v3.2.0
         id: semantic
         with:
           branch: main


### PR DESCRIPTION
Something broke with the older versions of the GHA.  This fix worked in a different repo.