### PR TITLE
refactor: remove platformName

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -2,7 +2,6 @@ import type { Action, Click, CohortMembership, Impression, View } from './types/
 import type { EventLogger, EventLoggerArguments } from './types/logger';
 import { createEventLogger } from './logger';
 
-const platformName = 'test';
 const snowplowTrackers: Array<string> | string | undefined = undefined;
 
 interface MockSnowplow {
@@ -36,7 +35,6 @@ describe('logCohortMembership', () => {
   it('success', () => {
     const snowplow = createMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -51,7 +49,7 @@ describe('logCohortMembership', () => {
       [
         {
           event: {
-            schema: 'iglu:ai.promoted.test/cohortmembership/jsonschema/1-0-0',
+            schema: 'iglu:ai.promoted/cohortmembership/jsonschema/1-0-0',
             data: {
               cohortId: 'experiment1',
               arm: 'TREATMENT',
@@ -66,7 +64,6 @@ describe('logCohortMembership', () => {
   it('error', () => {
     const snowplow = createThrowingMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -83,7 +80,6 @@ describe('logView', () => {
   it('success', () => {
     const snowplow = createMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -113,7 +109,6 @@ describe('logView', () => {
   it('error', () => {
     const snowplow = createThrowingMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
     });
 
@@ -128,7 +123,6 @@ describe('logImpression', () => {
   it('success', () => {
     const snowplow = createMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -142,7 +136,7 @@ describe('logImpression', () => {
       [
         {
           event: {
-            schema: 'iglu:ai.promoted.test/impression/jsonschema/1-0-0',
+            schema: 'iglu:ai.promoted/impression/jsonschema/1-0-0',
             data: {
               impressionId: 'abc-xyz',
             },
@@ -156,7 +150,6 @@ describe('logImpression', () => {
   it('error', () => {
     const snowplow = createThrowingMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
     });
 
@@ -171,7 +164,6 @@ describe('logAction', () => {
   it('success', () => {
     const snowplow = createMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -185,7 +177,7 @@ describe('logAction', () => {
       [
         {
           event: {
-            schema: 'iglu:ai.promoted.test/action/jsonschema/1-0-0',
+            schema: 'iglu:ai.promoted/action/jsonschema/1-0-0',
             data: {
               impressionId: 'abc-xyz',
             },
@@ -199,7 +191,6 @@ describe('logAction', () => {
   it('error', () => {
     const snowplow = createThrowingMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
     });
 
@@ -213,7 +204,6 @@ describe('logAction', () => {
     it('success - convert amount to micros', () => {
       const snowplow = createMockSnowplow();
       const logger = createTestEventLogger({
-        platformName,
         snowplow,
         snowplowTrackers,
       });
@@ -240,7 +230,7 @@ describe('logAction', () => {
         [
           {
             event: {
-              schema: 'iglu:ai.promoted.test/action/jsonschema/1-0-0',
+              schema: 'iglu:ai.promoted/action/jsonschema/1-0-0',
               data: {
                 impressionId: 'abc-xyz',
                 actionType: 'CHECKOUT',
@@ -267,7 +257,6 @@ describe('logAction', () => {
     it('error - quantity should be non-zero', () => {
       const snowplow = createMockSnowplow();
       const logger = createTestEventLogger({
-        platformName,
         snowplow,
       });
 
@@ -293,7 +282,6 @@ describe('logAction', () => {
     it('error - do not set both amount and amountMicros', () => {
       const snowplow = createMockSnowplow();
       const logger = createTestEventLogger({
-        platformName,
         snowplow,
       });
 
@@ -323,7 +311,6 @@ describe('logClick', () => {
   it('success', () => {
     const snowplow = createMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -339,7 +326,7 @@ describe('logClick', () => {
       [
         {
           event: {
-            schema: 'iglu:ai.promoted.test/action/jsonschema/1-0-0',
+            schema: 'iglu:ai.promoted/action/jsonschema/1-0-0',
             data: {
               actionType: 2,
               elementId: 'element-id',
@@ -358,7 +345,6 @@ describe('logClick', () => {
   it('error', () => {
     const snowplow = createThrowingMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
     });
 
@@ -409,7 +395,6 @@ describe('mergeBaseUserInfo', () => {
     const snowplow = createMockSnowplow();
     const logger = createTestEventLogger({
       ...args,
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -424,7 +409,7 @@ describe('mergeBaseUserInfo', () => {
       [
         {
           event: {
-            schema: 'iglu:ai.promoted.test/impression/jsonschema/1-0-0',
+            schema: 'iglu:ai.promoted/impression/jsonschema/1-0-0',
             data: {
               impressionId: 'abc-xyz',
               ...expectedData,
@@ -457,7 +442,6 @@ describe('snowplowTrackers', () => {
   ) => {
     const snowplow = createMockSnowplow();
     const logger = createTestEventLogger({
-      platformName,
       snowplow,
       snowplowTrackers,
     });
@@ -471,7 +455,7 @@ describe('snowplowTrackers', () => {
       [
         {
           event: {
-            schema: 'iglu:ai.promoted.test/impression/jsonschema/1-0-0',
+            schema: 'iglu:ai.promoted/impression/jsonschema/1-0-0',
             data: {
               impressionId: 'abc-xyz',
             },

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -33,13 +33,6 @@ const requiredError = (field: string) => new Error(`${field} is required`);
  * to reduce memory pressure.
  */
 export class EventLoggerImpl implements EventLogger {
-  private platformName: string;
-
-  // Delay generation until needed since not all pages log all types of schemas.
-  private cohortMembershipIgluSchema?: string;
-  private impressionIgluSchema?: string;
-  private actionIgluSchema?: string;
-
   private handleError: (err: Error) => void;
   private getUserInfo?: () => UserInfo | undefined;
   private snowplow: Snowplow;
@@ -49,7 +42,6 @@ export class EventLoggerImpl implements EventLogger {
    * @params {EventLoggerArguments} args The arguments for the logger.
    */
   public constructor(args: EventLoggerArguments) {
-    this.platformName = args.platformName;
     this.handleError = args.handleError;
     this.getUserInfo = args.getUserInfo;
     this.snowplow = args.snowplow;
@@ -72,41 +64,11 @@ export class EventLoggerImpl implements EventLogger {
     }
   };
 
-  /**
-   * Returns the CohortMembership IGLU Schema URL.  As a function to delay string construction.
-   */
-  private getCohortMembershipIgluSchema() {
-    if (!this.cohortMembershipIgluSchema) {
-      this.cohortMembershipIgluSchema = `iglu:ai.promoted.${this.platformName}/cohortmembership/jsonschema/1-0-0`;
-    }
-    return this.cohortMembershipIgluSchema;
-  }
-
-  /**
-   * Returns the Impression IGLU Schema URL.  As a function to delay string construction.
-   */
-  private getImpressionIgluSchema() {
-    if (!this.impressionIgluSchema) {
-      this.impressionIgluSchema = `iglu:ai.promoted.${this.platformName}/impression/jsonschema/1-0-0`;
-    }
-    return this.impressionIgluSchema;
-  }
-
-  /**
-   * Returns the Action IGLU Schema URL.  As a function to delay string construction.
-   */
-  private getActionIgluSchema() {
-    if (!this.actionIgluSchema) {
-      this.actionIgluSchema = `iglu:ai.promoted.${this.platformName}/action/jsonschema/1-0-0`;
-    }
-    return this.actionIgluSchema;
-  }
-
   logCohortMembership = (cohortMembership: CohortMembership) => {
     this.snowplow.trackSelfDescribingEvent(
       {
         event: {
-          schema: this.getCohortMembershipIgluSchema(),
+          schema: 'iglu:ai.promoted/cohortmembership/jsonschema/1-0-0',
           data: this.mergeBaseUserInfo(cohortMembership) as any,
         },
       },
@@ -127,7 +89,7 @@ export class EventLoggerImpl implements EventLogger {
     this.snowplow.trackSelfDescribingEvent(
       {
         event: {
-          schema: this.getImpressionIgluSchema(),
+          schema: 'iglu:ai.promoted/impression/jsonschema/1-0-0',
           data: this.mergeBaseUserInfo(impression) as any,
         },
       },
@@ -140,7 +102,7 @@ export class EventLoggerImpl implements EventLogger {
     this.snowplow.trackSelfDescribingEvent(
       {
         event: {
-          schema: this.getActionIgluSchema(),
+          schema: 'iglu:ai.promoted/action/jsonschema/1-0-0',
           data: this.mergeBaseUserInfo(action) as any,
         },
       },

--- a/src/noop-logger.test.ts
+++ b/src/noop-logger.test.ts
@@ -1,8 +1,6 @@
 import { createEventLogger } from './logger';
 import type { Snowplow } from './types/logger';
 
-const platformName = 'test';
-
 const createMockSnowplow = (): Snowplow => ({
   trackSelfDescribingEvent: jest.fn(),
   trackPageView: jest.fn(),
@@ -13,7 +11,6 @@ describe('disabled logging', () => {
     const snowplow = createMockSnowplow();
     const logger = createEventLogger({
       enabled: false,
-      platformName,
       snowplow,
       handleError: (e) => {
         throw e;

--- a/src/types/logger.d.ts
+++ b/src/types/logger.d.ts
@@ -46,11 +46,6 @@ interface EventLogger {
  */
 export interface EventLoggerArguments {
   /**
-   * The name of your Platform in Promoted's configuration.
-   */
-  platformName: string;
-
-  /**
    * A smaller Snowplow interface.  This is needed so we can keep Snowplow as a
    * peer dependency.
    */


### PR DESCRIPTION
PRO-6795

BREAKING CHANGE: this removes a previously required field.

After removing the validation, the platform subdomain is not needed anymore.

TESTING=ran unit tests